### PR TITLE
Health Store Manager improvements pt. 1

### DIFF
--- a/FinalChallenge.xcodeproj/project.pbxproj
+++ b/FinalChallenge.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		275FE886231D3ECE001695D2 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 275FE885231D3ECE001695D2 /* CoreDataManager.swift */; };
 		275FE888231D4CBD001695D2 /* HealthStoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 275FE887231D4CBD001695D2 /* HealthStoreManager.swift */; };
 		275FE88C231D55CC001695D2 /* HealthKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 275FE88B231D55CC001695D2 /* HealthKit.framework */; };
+		27C56E5C231EADB0009CCAAB /* HealthStoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27C56E5B231EADB0009CCAAB /* HealthStoreService.swift */; };
 		303F5A8D231D617E0054587C /* Calendar+GetUpdateTimes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 303F5A8C231D617E0054587C /* Calendar+GetUpdateTimes.swift */; };
 		303F5A8F231D619F0054587C /* PointManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 303F5A8E231D619F0054587C /* PointManager.swift */; };
 /* End PBXBuildFile section */
@@ -39,6 +40,7 @@
 		275FE887231D4CBD001695D2 /* HealthStoreManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthStoreManager.swift; sourceTree = "<group>"; };
 		275FE889231D55CC001695D2 /* FinalChallenge.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = FinalChallenge.entitlements; sourceTree = "<group>"; };
 		275FE88B231D55CC001695D2 /* HealthKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HealthKit.framework; path = System/Library/Frameworks/HealthKit.framework; sourceTree = SDKROOT; };
+		27C56E5B231EADB0009CCAAB /* HealthStoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthStoreService.swift; sourceTree = "<group>"; };
 		303F5A8C231D617E0054587C /* Calendar+GetUpdateTimes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Calendar+GetUpdateTimes.swift"; sourceTree = "<group>"; };
 		303F5A8E231D619F0054587C /* PointManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -75,7 +77,6 @@
 		275FE861231D3664001695D2 /* FinalChallenge */ = {
 			isa = PBXGroup;
 			children = (
-				275FE889231D55CC001695D2 /* FinalChallenge.entitlements */,
 				275FE878231D3D33001695D2 /* Shared */,
 				275FE882231D3E66001695D2 /* Views */,
 				275FE881231D3E53001695D2 /* ViewControllers */,
@@ -85,6 +86,7 @@
 				275FE86E231D3666001695D2 /* LaunchScreen.storyboard */,
 				275FE871231D3666001695D2 /* Info.plist */,
 				275FE869231D3664001695D2 /* FinalChallenge.xcdatamodeld */,
+				275FE889231D55CC001695D2 /* FinalChallenge.entitlements */,
 			);
 			path = FinalChallenge;
 			sourceTree = "<group>";
@@ -92,10 +94,10 @@
 		275FE878231D3D33001695D2 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				27C56E5D231EB5DF009CCAAB /* HealthKit */,
 				303F5A8B231D61640054587C /* Extensions */,
 				275FE879231D3D39001695D2 /* Protocols */,
 				275FE885231D3ECE001695D2 /* CoreDataManager.swift */,
-				275FE887231D4CBD001695D2 /* HealthStoreManager.swift */,
 				303F5A8E231D619F0054587C /* PointManager.swift */,
 			);
 			path = Shared;
@@ -132,6 +134,15 @@
 				275FE88B231D55CC001695D2 /* HealthKit.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		27C56E5D231EB5DF009CCAAB /* HealthKit */ = {
+			isa = PBXGroup;
+			children = (
+				27C56E5B231EADB0009CCAAB /* HealthStoreService.swift */,
+				275FE887231D4CBD001695D2 /* HealthStoreManager.swift */,
+			);
+			path = HealthKit;
 			sourceTree = "<group>";
 		};
 		303F5A8B231D61640054587C /* Extensions */ = {
@@ -249,6 +260,7 @@
 				275FE888231D4CBD001695D2 /* HealthStoreManager.swift in Sources */,
 				275FE886231D3ECE001695D2 /* CoreDataManager.swift in Sources */,
 				275FE87B231D3D46001695D2 /* CodeView.swift in Sources */,
+				27C56E5C231EADB0009CCAAB /* HealthStoreService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FinalChallenge/AppDelegate.swift
+++ b/FinalChallenge/AppDelegate.swift
@@ -23,19 +23,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ) -> Bool {
 
         let healthStoreManager = HealthStoreManager()
-        healthStoreManager.requestAuthorization { (success) in
-            print("HealthKit authored: \(success)")
-        }
-
-        guard let stepCountType = HKObjectType.quantityType(forIdentifier: .stepCount) else { return true }
-        healthStoreManager.quantitySum(of: stepCountType) { (result) in
+        healthStoreManager.requestAuthorization { (result) in
             switch result {
-            case .success(let statistics):
-                if let quantity = statistics.sumQuantity() {
-                    print(quantity.doubleValue(for: HKUnit.count()))
-                }
+            case .success(let isAuthorized):
+                print("HealthKit authored: \(isAuthorized)")
             case .failure(let error):
-                print(error.localizedDescription)
+                print(error)
             }
         }
 

--- a/FinalChallenge/Shared/HealthKit/HealthStoreManager.swift
+++ b/FinalChallenge/Shared/HealthKit/HealthStoreManager.swift
@@ -22,12 +22,9 @@ final class HealthStoreManager {
     /// - Parameter completion: Executado ao final do método, tem como parâmentro "true" em caso de sucesso e
     /// "false" em caso de fracasso.
     func requestAuthorization(completion: @escaping(ResultHandler<Bool>)) {
-        guard HKHealthStore.isHealthDataAvailable(),
-            let stepCountType = HKObjectType.quantityType(forIdentifier: .stepCount) else {
-                return completion(.success(false))
-        }
+        let readTypes = HealthStoreService.allTypes
 
-        HealthStoreManager.healthStore.requestAuthorization(toShare: [], read: [stepCountType]) { (success, error) in
+        HealthStoreManager.healthStore.requestAuthorization(toShare: [], read: readTypes) { (success, error) in
             if let error = error {
                 completion(.failure(error))
             }

--- a/FinalChallenge/Shared/HealthKit/HealthStoreService.swift
+++ b/FinalChallenge/Shared/HealthKit/HealthStoreService.swift
@@ -1,0 +1,26 @@
+//
+//  HealthStoreService.swift
+//  FinalChallenge
+//
+//  Created by Matheus Oliveira Costa on 03/09/19.
+//  Copyright © 2019 The Rest of Us. All rights reserved.
+//
+
+import Foundation
+import HealthKit
+
+enum HealthStoreService {
+    case stepCount
+
+    var type: HKObjectType? {
+        switch self {
+        case .stepCount:
+            return HKObjectType.quantityType(forIdentifier: .stepCount)
+        }
+    }
+
+    var queryPredicate: NSPredicate? {
+        return nil
+    }
+
+}

--- a/FinalChallenge/Shared/HealthKit/HealthStoreService.swift
+++ b/FinalChallenge/Shared/HealthKit/HealthStoreService.swift
@@ -9,18 +9,27 @@
 import Foundation
 import HealthKit
 
-enum HealthStoreService {
+enum HealthStoreService: CaseIterable {
     case stepCount
+    case distanceWalkingRunning
 
     var type: HKObjectType? {
         switch self {
         case .stepCount:
             return HKObjectType.quantityType(forIdentifier: .stepCount)
+        case .distanceWalkingRunning:
+            return HKObjectType.quantityType(forIdentifier: .distanceWalkingRunning)
         }
     }
 
     var queryPredicate: NSPredicate? {
         return nil
+    }
+
+    static var allTypes: Set<HKObjectType> {
+        let types = HealthStoreService.allCases.compactMap { $0.type }
+
+        return Set(types)
     }
 
 }

--- a/FinalChallenge/Shared/HealthStoreManager.swift
+++ b/FinalChallenge/Shared/HealthStoreManager.swift
@@ -11,7 +11,7 @@ import HealthKit
 
 final class HealthStoreManager {
 
-    // FIXME: Remover essa variável estática e usar outra coisa
+    // FIXME: Remover essa variável estática e fazer de outra forma
     static var healthStore = HKHealthStore()
 
     /// Solicita autorização do usuário para leitura dos dados necessários para o app.
@@ -34,7 +34,6 @@ final class HealthStoreManager {
         }
     }
 
-
     /// Executa uma query na `HKHealthStore` pelos samples do tipo passado como parâmetro e retorna o
     /// resultado do somatório das quantidades desde o intervalo de 1 hora.
     /// - Parameter sampleType: Tipo do sample a ser buscado
@@ -45,7 +44,7 @@ final class HealthStoreManager {
         let calendar = Calendar.current
         let now = Date()
         let lastHour = calendar.date(byAdding: .hour, value: -1, to: now)
-        
+
         let predicate = HKQuery.predicateForSamples(
             withStart: lastHour, end: now, options: .strictStartDate)
 
@@ -65,9 +64,35 @@ final class HealthStoreManager {
 
             completion(.success(result))
         }
-        
+
         // Executa a query na store
         HealthStoreManager.healthStore.execute(statisticsQuery)
+    }
+
+    /// Executa uma query para obter os samples de um determinado tipo passado como parâmetro.
+    /// - Parameter sampleType: Tipo do sample a ser buscado
+    /// - Parameter completion: Callback para ser executado após a consulta
+    func samples(
+        of sampleType: HKSampleType, completion: @escaping((Result<[HKSample], Error>) -> Void)) {
+
+        let sampleQuery = HKSampleQuery(
+            sampleType: sampleType,
+            predicate: nil,
+            limit: HKObjectQueryNoLimit,
+            sortDescriptors: nil
+        ) { (_, samples, error) in
+            guard let actualSamples = samples, error == nil else {
+                if let error = error {
+                    completion(.failure(error))
+                }
+                return
+            }
+
+            completion(.success(actualSamples))
+        }
+
+        // Executa a query na store
+        HealthStoreManager.healthStore.execute(sampleQuery)
     }
 
 }


### PR DESCRIPTION
Troquei para o manager depender de um enum que configura as queries que deixam as coisas mais genéricas. Basicamente é para quando precisar de uma nova query configurar o enum `HealthStoreService` em com ela deve ser.